### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow==2.3.0
 pillow==6.2.0
 numpy==1.16.5
-streamlit==0.62.0
+streamlit==0.67.0


### PR DESCRIPTION
Changed the streamlit version (0.64.0 to 0.67.0) to solve the KeyError: 'deprecation.showfileUploaderEncoding' while deploying in Streamlit sharing.